### PR TITLE
Initial collectd::packages support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ and [realityforge](https://github.com/realityforge-cookbooks/collectd).
 
 ## Recipes
 
-* `recipe[collectd]` will install collectd.
+* `recipe[collectd]` will install collectd from source.
 * `recipe[collectd::attribute_driven]` will install collectd via node attributes.
+* `recipe[collectd::packages]` will install collectd (and other plugins) from packages
 
 ## Usage
 

--- a/attributes/packages.rb
+++ b/attributes/packages.rb
@@ -1,0 +1,1 @@
+default["collectd"]["packages"] = [ "collectd" ]

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -1,0 +1,9 @@
+node["collectd"]["packages"].each do |pkg|
+  package pkg
+end
+
+service "collectd" do
+  supports :status => true, :restart => true, :reload => true
+  action [ :enable, :start ]
+  only_if { node["collectd"]["packages"].include?("collectd") }
+end


### PR DESCRIPTION
In case you don't want to install from source. The attribute_driven recipe needs some slight fixing (not included) to handle source vs distro package configuration directory location.
