### PR TITLE
Fix for RHEL5 package support for compiling collectd

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,6 +1,6 @@
 include_recipe "build-essential"
 
-if node["platform_family"] == "rhel"
+if node["platform_family"] == "rhel" && node["platform_version"].to_i > 5
   %w{ perl-ExtUtils-Embed perl-ExtUtils-MakeMaker }.each do |pkg|
     package pkg
   end


### PR DESCRIPTION
RHEL5 isn't happy trying to install missing packages. Might only be RHEL6 that needs them but for now fixes the issue until more testing can be done.
