### PR TITLE
collectd 5.1.1 by default instead of 5.1.0

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,7 @@
-default["collectd"]["version"]            = "5.1.0"
+default["collectd"]["version"]            = "5.1.1"
 default["collectd"]["dir"]                = "/opt/collectd"
 default["collectd"]["url"]                = "http://collectd.org/files/collectd-#{node["collectd"]["version"]}.tar.gz"
-default["collectd"]["checksum"]           = "521d4be7df5bc1124b7b9ea88227e95839a5f7c1b704a5bde0f60f058ec6eecb"
+default["collectd"]["checksum"]           = "cb361deeda00bece54cec2f7a2c368ccea4ac1c4a83388a0dae0435ba8969ee1"
 default["collectd"]["interval"]           = 10
 default["collectd"]["read_threads"]       = 5
 default["collectd"]["name"]               = node["fqdn"]


### PR DESCRIPTION
Newer patch release of collectd.
