### PR TITLE
use create_if_missing to save on bandwidth

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -77,6 +77,7 @@ remote_file "#{Chef::Config[:file_cache_path]}/collectd-#{node["collectd"]["vers
   source node["collectd"]["url"]
   checksum node["collectd"]["checksum"]
   notifies :run, resources(:bash => "install-collectd"), :immediately
+  action :create_if_missing
 end
 
 template "/etc/init.d/collectd" do


### PR DESCRIPTION
the default remote_file will download each time. This will save on bandwidth so the download only happens once (and doesn't hammer collectd.org)
