### PR TITLE
Write_graphite template is missing Host and Port directives

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,7 +26,10 @@ suites:
       version: 5.3.0
       url: http://fossies.org/linux/privat/collectd-5.3.0.tar.gz
       checksum: 3089a9784e02ebc207b4ac88a507922f8aa75fca8303e9aac51d8fc6c247daf4
+      graphite_ipaddress: localhost
       plugins:
+        write_graphite:
+          config: { Prefix: "collectd." }
         syslog:
           config: { LogLevel: "Info" }
         disk: { }

--- a/recipes/attribute_driven.rb
+++ b/recipes/attribute_driven.rb
@@ -1,7 +1,5 @@
 # treat the graphite plugin specially: set address from search or attributes
-if node.default["collectd"]["plugins"].key?("write_graphite")
-  write_graphite = node.default["collectd"]["plugins"]["write_graphite"]
-
+if node["collectd"]["plugins"].key?("write_graphite")
   if node["collectd"]["graphite_ipaddress"].empty?
     if Chef::Config[:solo]
       Chef::Application.fatal!("Graphite plugin enabled but no Graphite server configured.")
@@ -11,12 +9,13 @@ if node.default["collectd"]["plugins"].key?("write_graphite")
     if graphite_server_results.empty?
       Chef::Application.fatal!("Graphite plugin enabled but no Graphite server found.")
     else
-      write_graphite["config"]["Host"] = graphite_server_results[0]["ipaddress"]
+      node.set["collectd"]["plugins"]["write_graphite"]["config"]["Host"] = graphite_server_results[0]["ipaddress"]
     end
   else
-    write_graphite["config"]["Host"] = node["collectd"]["graphite_ipaddress"]
+    node.set["collectd"]["plugins"]["write_graphite"]["config"]["Host"] = node["collectd"]["graphite_ipaddress"]
   end
-  write_graphite["config"]["Port"] = 2003
+
+  node.set["collectd"]["plugins"]["write_graphite"]["config"]["Port"] = 2003
 end
 
 # flush all of configuration to conf.d/


### PR DESCRIPTION
Not sure why Chef isn't adding the Host and Port fields. I have two roles (base and monitoring) set up with client and server-specific attributes. This is a snippet from the monitoring role.

``` ruby
   'collectd' => {
      'graphite_ipaddress' => 'localhost',
        'plugins' => {
          'write_graphite' => {
            'config' => {
              'Prefix' => 'collectd.',
              'StoreRates' => true,
              'AlwaysAppendDS' => false,
              'EscapeCharacter' => '_'
          }
```

Which creates the following on my VM

``` ruby
#
# This file is generated by Chef
# Do not edit, changes will be overwritten
#
LoadPlugin "write_graphite"

<Plugin "write_graphite">
  <Carbon>
  Prefix "collectd."
  StoreRates true
  AlwaysAppendDS false
  EscapeCharacter "_"
  </Carbon>
</Plugin>
```

Looking at the logic in 'attribute_driven', it would appear that Host and Port would be inserted along with the attributes I specified in my role, but that's obviously not the case. The logic appears fine, but maybe I'm missing something here...

``` ruby
if node.default["collectd"]["plugins"].key?("write_graphite") # This exists so continue
  write_graphite = node.default["collectd"]["plugins"]["write_graphite"] # Grab the attributes that were set by the Chef Roles

  if node["collectd"]["graphite_ipaddress"].empty? # Not empty .. skip this
    [skipped]
  else 
    write_graphite["config"]["Host"] = node["collectd"]["graphite_ipaddress"] # Use the value I set, in this case 'localhost'
  end
  write_graphite["config"]["Port"] = 2003 # Set Port to 2003
end
```

While, this isn't really a big deal for me since I've alleviated it by adding the two keys to my role, I still think it's something worth checking out/fixing.
