### PR TITLE
Add recursive=true to config directory

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -109,6 +109,7 @@ end
 
 directory "#{node["collectd"]["dir"]}/etc/conf.d" do
   action :create
+  recursive true
 end
 
 service "collectd" do


### PR DESCRIPTION
Add recursive attribute due to the following issue (while running default recipe):

```
Compiled Resource:
------------------
# Declared in /tmp/vagrant-chef-1/chef-solo-1/cookbooks/collectd/recipes/default.rb:67:in `from_file'

directory("/opt/collectd/etc/conf.d") do
  provider Chef::Provider::Directory
  action [:create]
  retries 0
  retry_delay 2
  path "/opt/collectd/etc/conf.d"
  cookbook_name :collectd
  recipe_name "default"
end



[2013-11-10T09:29:16+00:00] INFO: Running queued delayed notifications before re-raising exception
[2013-11-10T09:29:16+00:00] ERROR: Running exception handlers
[2013-11-10T09:29:16+00:00] ERROR: Exception handlers complete
[2013-11-10T09:29:16+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2013-11-10T09:29:16+00:00] FATAL: Chef::Exceptions::EnclosingDirectoryDoesNotExist: directory[/opt/collectd/etc/conf.d] (collectd::default line 67) had an error: Chef::Exceptions::EnclosingDirectoryDoesNotExist: Parent directory /opt/collectd/etc does not exist, cannot create /opt/collectd/etc/conf.d
```
