### PR TITLE
fixes missing directory issue when creating collectd.conf

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -63,21 +63,19 @@ if node["collectd"]["plugins"]
   end
 end
 
+remote_file "#{Chef::Config[:file_cache_path]}/collectd-#{node["collectd"]["version"]}.tar.gz" do
+  source node["collectd"]["url"]
+  checksum node["collectd"]["checksum"]
+  action :create_if_missing
+end
+
 bash "install-collectd" do
   cwd Chef::Config[:file_cache_path]
   code <<-EOH
     tar -xzf collectd-#{node["collectd"]["version"]}.tar.gz
     (cd collectd-#{node["collectd"]["version"]} && ./configure --prefix=#{node["collectd"]["dir"]} && make && make install)
   EOH
-  action :nothing
   not_if "#{node["collectd"]["dir"]}/sbin/collectd -h 2>&1 | grep #{node["collectd"]["version"]}"
-end
-
-remote_file "#{Chef::Config[:file_cache_path]}/collectd-#{node["collectd"]["version"]}.tar.gz" do
-  source node["collectd"]["url"]
-  checksum node["collectd"]["checksum"]
-  notifies :run, "bash[install-collectd]", :immediately
-  action :create_if_missing
 end
 
 template "/etc/init.d/collectd" do


### PR DESCRIPTION
ERROR: template[/opt/collectd/etc/collectd.conf](collectd::default line 97) had an error: Chef::Exceptions::EnclosingDirectoryDoesNotExist: Parent directory /opt/collectd/etc does not exist
