### PR TITLE
Moved FQDNLookup configuration to default attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,6 +6,7 @@ default["collectd"]["checksum"]           = "853680936893df00bfc2be58f61ab9181fe
 default["collectd"]["interval"]           = 10
 default["collectd"]["read_threads"]       = 5
 default["collectd"]["name"]               = node["fqdn"]
+default["collectd"]["fqdnlookup"]         = true
 default["collectd"]["plugins"]            = Mash.new
 default["collectd"]["python_plugins"]     = Mash.new
 default["collectd"]["graphite_role"]      = "graphite"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -97,6 +97,7 @@ template "#{node["collectd"]["dir"]}/etc/collectd.conf" do
   source "collectd.conf.erb"
   variables(
     :name         => node["collectd"]["name"],
+    :fqdnlookup   => node["collectd"]["fqdnlookup"],
     :dir          => node["collectd"]["dir"],
     :interval     => node["collectd"]["interval"],
     :read_threads => node["collectd"]["read_threads"],

--- a/templates/default/collectd.conf.erb
+++ b/templates/default/collectd.conf.erb
@@ -4,7 +4,7 @@
 #
 
 Hostname "<%= @name %>"
-FQDNLookup true
+FQDNLookup <%= @fqdnlookup %>
 BaseDir "<%= @dir %>"
 PluginDir "<%= @dir %>/lib/collectd"
 TypesDB "<%= @dir %>/share/collectd/types.db"


### PR DESCRIPTION
Moved FQDNLookup to default attributes so it's possible to change
it in the Chef role definion. By default FQDNLookup is true
which is also Collectd default for it.