### PR TITLE
Switch to use "use_inline_resources" in providers

### DIFF
--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -1,3 +1,5 @@
+use_inline_resources
+
 action :create do
   template ::File.join(node["collectd"]["plugins_conf_dir"], "#{new_resource.name}.conf") do
     owner "root"
@@ -9,16 +11,12 @@ action :create do
       :name   => new_resource.name,
       :config => new_resource.config
     )
-    notifies :restart, "service[collectd]"
   end
-  new_resource.updated_by_last_action(true)
 end
 
 action :delete do
   file "#{new_resource.name} :delete #{node["collectd"]["plugins_conf_dir"]}/#{new_resource.name}.conf}"
     path ::File.join(node["collectd"]["plugins_conf_dir"], "#{new_resource.name}.conf") do
     action :delete
-    notifies :restart, "service[collectd]"
   end
-  new_resource.updated_by_last_action(true)
 end

--- a/providers/python_plugin.rb
+++ b/providers/python_plugin.rb
@@ -1,3 +1,5 @@
+use_inline_resources
+
 action :create do
   template ::File.join(node["collectd"]["plugins_conf_dir"], "#{new_resource.name}.conf") do
     owner "root"
@@ -11,7 +13,5 @@ action :create do
       :config => new_resource.config,
       :module_config => new_resource.module_config
     )
-    notifies :restart, "service[collectd]"
   end
-  new_resource.updated_by_last_action(true)
 end

--- a/recipes/attribute_driven.rb
+++ b/recipes/attribute_driven.rb
@@ -25,6 +25,7 @@ node["collectd"]["plugins"].each_pair do |plugin_key, definition|
     config definition["config"].to_hash if definition["config"]
     template definition["template"].to_s if definition["template"]
     cookbook definition["cookbook"].to_s if definition["cookbook"]
+    notifies :restart, "service[collectd]"
   end
 end
 
@@ -37,6 +38,7 @@ node["collectd"]["python_plugins"].each_pair do |plugin_key, definition|
     module_config definition["module_config"].to_hash
     template definition["template"].to_s if definition["template"]
     cookbook definition["cookbook"].to_s if definition["cookbook"]
+    notifies :restart, "service[collectd]"
   end
 end
 


### PR DESCRIPTION
Previously Chef notified every time that "plugin" resource were created
because providers were calling new_resource.updated_by_last_action(true)
every time.

This caused all Chef reports to contain "created" info even tho
it wasnt created.
Switched to use "use_inline_resources" to notify only
when template really change or get removed.
NOTE: this break support for old Chef (<11.0).