### PR TITLE
Add ChefSpec matchers

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,19 @@
+# For ChefSpec LWRP custom matchers:
+# https://github.com/sethvargo/chefspec#packaging-custom-matchers
+if defined?(ChefSpec)
+  def create_collectd_plugin(name)
+    ChefSpec::Matchers::ResourceMatcher.new(:collectd_plugin, :create, name)
+  end
+
+  def delete_collectd_plugin(name)
+    ChefSpec::Matchers::ResourceMatcher.new(:collectd_plugin, :delete, name)
+  end
+
+  def create_collectd_python_plugin(name)
+    ChefSpec::Matchers::ResourceMatcher.new(:collectd_plugin, :create, name)
+  end
+
+  def delete_collectd_python_plugin(name)
+    ChefSpec::Matchers::ResourceMatcher.new(:collectd_plugin, :delete, name)
+  end
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,23 @@
+require 'serverspec'
+
+set :backend, :exec
+set :path, '/sbin:/usr/local/sbin:$PATH'
+
+describe 'default' do
+  it 'service collectd should be running' do
+    expect(service 'collectd').to be_enabled
+    expect(service 'collectd').to be_running
+  end
+  it 'creates attribute-driven plugins' do
+    plugins = %w(cpu df disk interface memory swap syslog)
+    plugins.each do |plugin|
+      expect(file "/opt/collectd/etc/conf.d/#{plugin}.conf").to be_file
+    end
+  end
+  describe file('/opt/collectd/etc/conf.d/write_graphite.conf') do
+    it { should be_a_file }
+    its(:content) { should include 'Host "localhost"' }
+    its(:content) { should include 'Port 2003' }
+    its(:content) { should include 'Prefix "collectd."' }
+  end
+end


### PR DESCRIPTION
The addition of these matchers will allow ChefSpec testing of the collectd LWRPs:

```ruby
expect(chef_run).to create_collectd_plugin('interface').with(
  'config' => {
    'Interface' => 'lo',
    'IgnoreSelected' => true
  }
)
```

I have another commit ready for PR that will add a few ChefSpec tests to this cookbook, but it necessitates a change to the `attribute_driven` recipe, so I'm going to submit it separately (and after this has been merged).

I also added a basic ServerSpec test for Kitchen.

Thanks!