### PR TITLE
Add some ChefSpec tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: ruby
 gemfile:
    - test/support/Gemfile.ci
 rvm:
-  - 1.9.3
   - 2.1.1
+  - 2.2.2
 script: BUNDLE_GEMFILE=test/support/Gemfile.ci bundle exec rake foodcritic

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-site :opscode
+source 'https://supermarket.chef.io'
 
 metadata
 

--- a/recipes/attribute_driven.rb
+++ b/recipes/attribute_driven.rb
@@ -1,3 +1,5 @@
+include_recipe 'collectd::default'
+
 # treat the graphite plugin specially: set address from search or attributes
 if node["collectd"]["plugins"].key?("write_graphite")
   if node["collectd"]["graphite_ipaddress"].empty?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+require 'support/matchers'
+
+at_exit { ChefSpec::Coverage.report! }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
-require 'support/matchers'
 
 at_exit { ChefSpec::Coverage.report! }

--- a/spec/unit/attribute_driven_spec.rb
+++ b/spec/unit/attribute_driven_spec.rb
@@ -14,7 +14,7 @@ describe 'collectd::attribute_driven' do
     value['versions'].each do |version|
       context "on #{platform} #{version}" do
         let(:chef_run) do
-          ChefSpec::SoloRunner.new(platform: platform, version: version) do |node|
+          ChefSpec::SoloRunner.new(platform: platform, version: version, file_cache_path: '/var/chef/cache') do |node|
             node.set['collectd']['plugins'] = {
               'cpu' => {},
               'disk' => {},

--- a/spec/unit/attribute_driven_spec.rb
+++ b/spec/unit/attribute_driven_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe 'collectd::attribute_driven' do
+  platforms = {
+    'ubuntu' => {
+      'versions' => ['12.04', '14.04']
+    },
+    'centos' => {
+      'versions' => ['6.5', '6.6']
+    }
+  }
+
+  platforms.each do |platform, value|
+    value['versions'].each do |version|
+      context "on #{platform} #{version}" do
+        let(:chef_run) do
+          ChefSpec::SoloRunner.new(platform: platform, version: version) do |node|
+            node.set['collectd']['plugins'] = {
+              'cpu' => {},
+              'disk' => {},
+              'interface' => {
+                'config' => {
+                  'Interface' => 'lo',
+                  'IgnoreSelected' => true
+                }
+              },
+              'memory' => {}
+            }
+          end.converge described_recipe
+        end
+        before do
+          stub_command('/opt/collectd/sbin/collectd -h 2>&1 | grep 5.4.1').and_return(true)
+        end
+        it 'creates some plugins' do
+          expect(chef_run).to create_collectd_plugin('cpu')
+          expect(chef_run).to create_collectd_plugin('interface').with(
+            'config' => {
+              'Interface' => 'lo',
+              'IgnoreSelected' => true
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -14,7 +14,7 @@ describe 'collectd::default' do
     value['versions'].each do |version|
       context "on #{platform} #{version}" do
         let(:chef_run) do
-          ChefSpec::SoloRunner.new(platform: platform, version: version).converge described_recipe
+          ChefSpec::SoloRunner.new(platform: platform, version: version, file_cache_path: '/var/chef/cache').converge described_recipe
         end
         before do
           stub_command('/opt/collectd/sbin/collectd -h 2>&1 | grep 5.4.1').and_return(true)

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'collectd::default' do
+  platforms = {
+    'ubuntu' => {
+      'versions' => ['12.04', '14.04']
+    },
+    'centos' => {
+      'versions' => ['6.5', '6.6']
+    }
+  }
+
+  platforms.each do |platform, value|
+    value['versions'].each do |version|
+      context "on #{platform} #{version}" do
+        let(:chef_run) do
+          ChefSpec::SoloRunner.new(platform: platform, version: version).converge described_recipe
+        end
+        before do
+          stub_command('/opt/collectd/sbin/collectd -h 2>&1 | grep 5.4.1').and_return(true)
+        end
+        it 'enables and starts collectd' do
+          expect(chef_run).to enable_service 'collectd'
+          expect(chef_run).to start_service 'collectd'
+        end
+      end
+    end
+  end
+end

--- a/test/support/Gemfile.ci
+++ b/test/support/Gemfile.ci
@@ -1,4 +1,6 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem "rake"
-gem "foodcritic"
+gem 'rake'
+gem 'foodcritic', '4.0.0'
+gem 'chefspec', '4.2.0'
+gem 'berkshelf', '3.2.3'


### PR DESCRIPTION
This PR adds a couple ChefSpec tests.

As you can see, I had to include the `collectd::default` recipe in the `attribute_driven` recipe. This is because the `notifies :restart, "service[collectd]"` will error if used without the default recipe. Hopefully this change isn't objectionable.