### PR TITLE
Fix syntax error in packages recipe.

### DIFF
--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -2,4 +2,4 @@ node["collectd"]["packages"].each do |pkg|
   package pkg
 end
 
-include_recipe 'collectd::_service' only_if { node["collectd"]["packages"].include?("collectd") }
+include_recipe 'collectd::_service' if node["collectd"]["packages"].include?("collectd")


### PR DESCRIPTION
Berkshelf complains about the only_if here when it tries to upload this cookbook to my Chef 12 server. I'm pretty sure that only_if only works within a resource, so this should fix the problem.

```
E, [2015-05-22T20:17:49.086094 #6532] ERROR -- : Cookbook file /home/jenkins/.berkshelf/cookbooks/collectd-9b4a9f3eeee163c157d97522e927dd575f0a8f11/recipes/packages.rb has a ruby syntax error:
E, [2015-05-22T20:17:49.086192 #6532] ERROR -- : /home/jenkins/.berkshelf/cookbooks/collectd-9b4a9f3eeee163c157d97522e927dd575f0a8f11/recipes/packages.rb:5: syntax error, unexpected tIDENTIFIER, expecting keyword_end
E, [2015-05-22T20:17:49.086226 #6532] ERROR -- : ...pe 'collectd::_service' only_if { node["collectd"]["packages...
E, [2015-05-22T20:17:49.086253 #6532] ERROR -- : ...                               ^
E, [2015-05-22T20:17:49.093816 #6532] ERROR -- : Ridley::Errors::CookbookSyntaxError: Invalid ruby files in cookbook: collectd (1.1.1).
E, [2015-05-22T20:17:49.094208 #6532] ERROR -- : /home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/ridley-4.1.2/lib/ridley/chef/cookbook.rb:198:in `validate'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/ridley-4.1.2/lib/ridley/resources/cookbook_resource.rb:199:in `upload'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/celluloid-0.16.0/lib/celluloid/calls.rb:26:in `public_send'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/celluloid-0.16.0/lib/celluloid/calls.rb:26:in `dispatch'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/celluloid-0.16.0/lib/celluloid/calls.rb:63:in `dispatch'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/celluloid-0.16.0/lib/celluloid/cell.rb:60:in `block in invoke'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/celluloid-0.16.0/lib/celluloid/cell.rb:71:in `block in task'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/celluloid-0.16.0/lib/celluloid/actor.rb:357:in `block in task'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/celluloid-0.16.0/lib/celluloid/tasks.rb:57:in `block in initialize'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/celluloid-0.16.0/lib/celluloid/tasks/task_thread.rb:21:in `block in create'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/celluloid-0.16.0/lib/celluloid/thread_handle.rb:13:in `block in initialize'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/celluloid-0.16.0/lib/celluloid/actor_system.rb:32:in `block in get_thread'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/celluloid-0.16.0/lib/celluloid/internal_pool.rb:130:in `call'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/celluloid-0.16.0/lib/celluloid/internal_pool.rb:130:in `block in create'
(celluloid):0:in `remote procedure call'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/celluloid-0.16.0/lib/celluloid/calls.rb:92:in `value'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/celluloid-0.16.0/lib/celluloid/proxies/sync_proxy.rb:33:in `method_missing'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/berkshelf-3.2.4/lib/berkshelf/uploader.rb:55:in `block (2 levels) in upload'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/berkshelf-3.2.4/lib/berkshelf/uploader.rb:51:in `each'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/berkshelf-3.2.4/lib/berkshelf/uploader.rb:51:in `block in upload'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/ridley-4.1.2/lib/ridley/client.rb:38:in `open'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/ridley-4.1.2/lib/ridley.rb:51:in `open'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/berkshelf-3.2.4/lib/berkshelf.rb:144:in `ridley_connection'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/berkshelf-3.2.4/lib/berkshelf/uploader.rb:50:in `upload'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/berkshelf-3.2.4/lib/berkshelf/uploader.rb:37:in `run'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/berkshelf-3.2.4/lib/berkshelf/berksfile.rb:545:in `upload'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/berkshelf-3.2.4/lib/berkshelf/cli.rb:208:in `upload'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/berkshelf-3.2.4/lib/berkshelf/cli.rb:52:in `dispatch'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/berkshelf-3.2.4/lib/berkshelf/cli.rb:27:in `execute!'
/home/jenkins/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/berkshelf-3.2.4/bin/berks:5:in `<top (required)>'
/home/jenkins/.rbenv/versions/2.1.5/bin/berks:23:in `load'
/home/jenkins/.rbenv/versions/2.1.5/bin/berks:23:in `<main>'
```