### PR TITLE
Allow attribute-driven disabling of plugins.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -43,6 +43,8 @@ suites:
             ReportReserved: false
             FSType: [ "proc", "sysfs", "fusectl", "debugfs", "devtmpfs", "devpts", "tmpfs" ]
             IgnoreSelected: true
+        load:
+          enable: false
       python_plugins:
         rabbitmq:
           typesdb: "/mnt/pro..."

--- a/recipes/attribute_driven.rb
+++ b/recipes/attribute_driven.rb
@@ -22,11 +22,14 @@ end
 
 # flush all of configuration to conf.d/
 node["collectd"]["plugins"].each_pair do |plugin_key, definition|
+  enabled = (definition["enable"].nil? || definition["enable"] == true)
+
   # Graphite auto-discovery
   collectd_plugin plugin_key.to_s do
     config definition["config"].to_hash if definition["config"]
     template definition["template"].to_s if definition["template"]
     cookbook definition["cookbook"].to_s if definition["cookbook"]
+    action enabled ? :create : :delete
     notifies :restart, "service[collectd]"
   end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -14,6 +14,12 @@ describe 'default' do
       expect(file "/opt/collectd/etc/conf.d/#{plugin}.conf").to be_file
     end
   end
+  it 'does not create disabled attribute-driven plugins' do
+    plugins = %w(load)
+    plugins.each do |plugin|
+      expect(file "/opt/collectd/etc/conf.d/#{plugin}.conf").to_not be_a_file
+    end
+  end
   describe file('/opt/collectd/etc/conf.d/write_graphite.conf') do
     it { should be_a_file }
     its(:content) { should include 'Host "localhost"' }


### PR DESCRIPTION
This is a pretty simple change that just allows for an `enable` attribute within the plugin hash. The default behavior (nothing specified, so `nil`) will behave as before. So a `nil` or `true` value will perform a `:create` while any other value will perform a `:delete` action.