### PR TITLE
Use correct pidfile location

### DIFF
--- a/templates/default/collectd.init-rhel.erb
+++ b/templates/default/collectd.init-rhel.erb
@@ -7,7 +7,7 @@
 # processname: collectd
 # config: <%= @dir %>/etc/collectd.conf
 # config: /etc/sysconfig/collectd
-# pidfile: /var/run/collectd.pid
+# pidfile: <%= @dir %>/var/run/collectd.pid
 
 # Source function library.
 . /etc/init.d/functions


### PR DESCRIPTION
The rest of this init script takes @dir into account, but not pidfile?

Ran into an issue with systemd(Centos 7) thinking the pidfile wasn't written to yet, making chef-client spawn a new process every time it ran.