### PR TITLE
Attributes and improved package installs

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,13 +12,17 @@ default["collectd"]["graphite_role"]      = "graphite"
 default["collectd"]["graphite_ipaddress"] = ""
 
 default["collectd"]["source"]["version"]            = "5.4.1"
-default["collectd"]["source"]["dir"]                = "/opt/collectd"
-default["collectd"]["source"]["config_file"]        = ::File.join(node["collectd"]["dir"], "etc", "collectd.conf")
-default["collectd"]["source"]["plugins_conf_dir"]   = ::File.join(node["collectd"]["dir"], "etc", "conf.d")
+default["collectd"]["source"]["base_dir"]           = "/opt/collectd"
+default["collectd"]["source"]["config_file"]        = ::File.join(node["collectd"]["source"]["base_dir"], "etc", "collectd.conf")
+default["collectd"]["source"]["plugins_conf_dir"]   = ::File.join(node["collectd"]["source"]["base_dir"], "etc", "conf.d")
+default["collectd"]["source"]["plugins_dir"]        = ::File.join(node["collectd"]["source"]["base_dir"], "lib", "collectd")
+default["collectd"]["source"]["types_dir"]        = ::File.join(node["collectd"]["source"]["base_dir"], "share", "collectd")
 default["collectd"]["source"]["url"]                = "http://collectd.org/files/collectd-#{node["collectd"]["version"]}.tar.gz"
 default["collectd"]["source"]["checksum"]           = "853680936893df00bfc2be58f61ab9181fecb1cf45fc5cddcb7d25da98855f65"
 
 default["collectd"]["package"]["dir"]               = "/var/lib/collectd"
 default["collectd"]["package"]["config_file"]       = "/etc/collectd.conf"
 default["collectd"]["package"]["plugins_conf_dir"]  = "/etc/collectd.d"
+default["collectd"]["package"]["plugins_dir"]        = "/usr/lib64/collectd"
+default["collectd"]["package"]["types_dir"]         = "/usr/share/collectd/"
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,8 +1,4 @@
-default["collectd"]["version"]            = "5.4.1"
-default["collectd"]["dir"]                = "/opt/collectd"
-default["collectd"]["plugins_conf_dir"]    = ::File.join(node["collectd"]["dir"], "etc", "conf.d")
-default["collectd"]["url"]                = "http://collectd.org/files/collectd-#{node["collectd"]["version"]}.tar.gz"
-default["collectd"]["checksum"]           = "853680936893df00bfc2be58f61ab9181fecb1cf45fc5cddcb7d25da98855f65"
+
 default["collectd"]["interval"]           = 10
 default["collectd"]["read_threads"]       = 5
 default["collectd"]["write_queue_limit_high"] = 1_000_000
@@ -14,3 +10,15 @@ default["collectd"]["plugins"]            = Mash.new
 default["collectd"]["python_plugins"]     = Mash.new
 default["collectd"]["graphite_role"]      = "graphite"
 default["collectd"]["graphite_ipaddress"] = ""
+
+default["collectd"]["source"]["version"]            = "5.4.1"
+default["collectd"]["source"]["dir"]                = "/opt/collectd"
+default["collectd"]["source"]["config_file"]        = ::File.join(node["collectd"]["dir"], "etc", "collectd.conf")
+default["collectd"]["source"]["plugins_conf_dir"]   = ::File.join(node["collectd"]["dir"], "etc", "conf.d")
+default["collectd"]["source"]["url"]                = "http://collectd.org/files/collectd-#{node["collectd"]["version"]}.tar.gz"
+default["collectd"]["source"]["checksum"]           = "853680936893df00bfc2be58f61ab9181fecb1cf45fc5cddcb7d25da98855f65"
+
+default["collectd"]["package"]["dir"]               = "/var/lib/collectd"
+default["collectd"]["package"]["config_file"]       = "/etc/collectd.conf"
+default["collectd"]["package"]["plugins_conf_dir"]  = "/etc/collectd.d"
+

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -2,6 +2,30 @@ node["collectd"]["packages"].each do |pkg|
   package pkg
 end
 
+template node["collectd"]["package"]["config_file"] do
+  mode "0644"
+  source "collectd.conf.erb"
+  variables(
+    :name         => node["collectd"]["name"],
+    :fqdnlookup   => node["collectd"]["fqdnlookup"],
+    :base_dir     => node["collectd"]["package"]["base_dir"],
+    :plugins_conf_dir  => node["collectd"]["package"]["plugins_conf_dir"],
+    :plugins_dir  => node["collectd"]["package"]["plugins_dir"],
+    :types_dir    => node["collectd"]["package"]["types_dir"],
+    :interval     => node["collectd"]["interval"],
+    :read_threads => node["collectd"]["read_threads"],
+    :write_queue_limit_high => node["collectd"]["write_queue_limit_high"],
+    :write_queue_limit_low => node["collectd"]["write_queue_limit_low"],
+    :collect_internal_stats => node["collectd"]["collect_internal_stats"],
+    :plugins      => node["collectd"]["plugins"]
+  )
+  notifies :restart, "service[collectd]"
+end
+
+directory node["collectd"]["package"]["plugins_conf_dir"] do
+  action :create
+end
+
 include_recipe 'collectd-ng::_service' do
   only_if { node["collectd"]["packages"].include?("collectd") }
 end

--- a/templates/default/collectd.conf.erb
+++ b/templates/default/collectd.conf.erb
@@ -5,9 +5,9 @@
 
 Hostname "<%= @name %>"
 FQDNLookup <%= @fqdnlookup %>
-BaseDir "<%= @dir %>"
-PluginDir "<%= @dir %>/lib/collectd"
-TypesDB "<%= @dir %>/share/collectd/types.db"
+BaseDir "<%= @base_dir %>"
+PluginDir "<%= @plugins_dir %>"
+TypesDB "<%= @types_dir %>/types.db"
 Interval <%= @interval %>
 ReadThreads <%= @read_threads %>
 WriteQueueLimitHigh <%= @write_queue_limit_high %>
@@ -15,5 +15,5 @@ WriteQueueLimitLow <%= @write_queue_limit_low %>
 CollectInternalStats <%= @collect_internal_stats %>
 
 <% unless @plugins.empty? %>
-Include "<%= @dir %>/etc/conf.d/*.conf"
+Include "<%= @plugins_conf_dir %>/*.conf"
 <% end %>


### PR DESCRIPTION
Move various paths to attributes and uses these for source and package installs.
This cleanup makes it possible to manage collectd.conf for package installs.

This fixes issue #66 
