### PR TITLE
Update write_graphite template

### DIFF
--- a/templates/default/plugin.conf.erb
+++ b/templates/default/plugin.conf.erb
@@ -6,7 +6,7 @@ LoadPlugin "<%= @name %>"
 
 <% if not @config.empty? %>
 <Plugin "<%= @name %>">
-  <%= "<Carbon>" if @name == "write_graphite" %>
+  <%= "<Node>" if @name == "write_graphite" %>
   <%= "<URL #{collectd_option(@config.delete("URL"))}>" if @name == "write_http" %>
   <% @config.each_pair do |key, value|
     if value.is_a? Array
@@ -15,7 +15,7 @@ LoadPlugin "<%= @name %>"
   <% end else %>
   <%= key %> <%= collectd_option(value) %>
   <% end end %>
-  <%= "</Carbon>" if @name == "write_graphite" %>
+  <%= "</Node>" if @name == "write_graphite" %>
   <%= "</URL >" if @name == "write_http" %>
 </Plugin>
 <% end %>

--- a/templates/default/plugin.conf.erb
+++ b/templates/default/plugin.conf.erb
@@ -6,7 +6,7 @@ LoadPlugin "<%= @name %>"
 
 <% if not @config.empty? %>
 <Plugin "<%= @name %>">
-  <%= "<Node>" if @name == "write_graphite" %>
+  <%= "<Node \"#{node['hostname']}\">" if @name == "write_graphite" %>
   <%= "<URL #{collectd_option(@config.delete("URL"))}>" if @name == "write_http" %>
   <% @config.each_pair do |key, value|
     if value.is_a? Array


### PR DESCRIPTION
Re-doing this on the 'develop' branch:

According to the latest version of the "write_graphite" plugin, the <Carbon></Carbon> should now be <Node "example"></Node> (see https://collectd.org/wiki/index.php/Plugin:Write_Graphite). This PR updates the template to use the node hostname for the name of the write_graphite node.