### PR TITLE
Enabling packages during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ work done by [coderanger](https://github.com/coderanger/chef-collectd) and
 * `node["collectd"]["graphite_ipaddress"]` – IP address to Graphite server if
   you're trying to target one that isn't searchable.
 * `node["collectd"]["packages"]` – List of collectd packages.
+* `node["collectd"]["configure_flag"]` – Flag for enabling non-default collectd packages. 
 
 ## Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,3 +14,4 @@ default["collectd"]["plugins"]            = Mash.new
 default["collectd"]["python_plugins"]     = Mash.new
 default["collectd"]["graphite_role"]      = "graphite"
 default["collectd"]["graphite_ipaddress"] = ""
+default["collectd"]["configure_flag"] = ""

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -76,7 +76,7 @@ bash "install-collectd" do
   cwd Chef::Config[:file_cache_path]
   code <<-EOH
     tar -xzf collectd-#{node["collectd"]["version"]}.tar.gz
-    (cd collectd-#{node["collectd"]["version"]} && ./configure --prefix=#{node["collectd"]["dir"]} && make && make install)
+    (cd collectd-#{node["collectd"]["version"]} && ./configure --prefix=#{node["collectd"]["dir"]} #{node["collectd"]["configure_flag"]} && make && make install)
   EOH
   not_if "#{node["collectd"]["dir"]}/sbin/collectd -h 2>&1 | grep #{node["collectd"]["version"]}"
 end


### PR DESCRIPTION
Added a configuration flag attribute and reference in the installation block of default.rb. This will allow enabling non-default packages during installation from source. 